### PR TITLE
Added revert for `onUninstall` in `MultipleOwnerECDSAValidator`

### DIFF
--- a/src/modular-etherspot-wallet/modules/validators/MultipleOwnerECDSAValidator.sol
+++ b/src/modular-etherspot-wallet/modules/validators/MultipleOwnerECDSAValidator.sol
@@ -20,6 +20,7 @@ contract MultipleOwnerECDSAValidator is EIP712, IValidator {
     string constant VERSION = "1.0.0";
 
     error InvalidExec();
+    error RequiredModule();
 
     mapping(address => bool) internal _initialized;
 
@@ -29,8 +30,7 @@ contract MultipleOwnerECDSAValidator is EIP712, IValidator {
     }
 
     function onUninstall(bytes calldata data) external override {
-        if (!isInitialized(msg.sender)) revert NotInitialized(msg.sender);
-        _initialized[msg.sender] = false;
+        revert RequiredModule();
     }
 
     function isInitialized(

--- a/test/foundry/wallet/ModularEtherspotWallet.t.sol
+++ b/test/foundry/wallet/ModularEtherspotWallet.t.sol
@@ -73,6 +73,7 @@ contract ModularEtherspotWalletTest is TestAdvancedUtils {
     error ProposalTimelocked();
     error OnlyOwnerOrGuardianOrSelf();
     error OnlyProxy();
+    error RequiredModule();
 
     function setUp() public override {
         super.setUp();
@@ -881,7 +882,7 @@ contract ModularEtherspotWalletTest is TestAdvancedUtils {
         mewAccount.discardCurrentProposal();
     }
 
-    function test_uninstallModule() public {
+    function test_fail_uninstallModule_RequiredModule() public {
         mew = setupMEW();
         vm.startPrank(address(mewAccount));
         assertTrue(mew.isModuleInstalled(1, address(ecdsaValidator), ""));
@@ -895,8 +896,8 @@ contract ModularEtherspotWalletTest is TestAdvancedUtils {
             address(ecdsaValidator),
             abi.encode(address(0x1), hex"")
         );
+        vm.expectRevert(RequiredModule.selector);
         defaultExecutor.execBatch(IERC7579Account(mew), batchCalls);
-        assertFalse(mew.isModuleInstalled(1, address(ecdsaValidator), ""));
         vm.stopPrank();
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Added `RequiredModule()` revert on `onUninstall` for `MultipleOwnerECDSAValidator`.
- Added test in suite to check revert.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Uninstalling this module with no other validator modules in the wallet will cause issues with signature validation. Keep this module as a required module to avoid this issue.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Test created to check revert.


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
