### PR TITLE
fix: pagination tests and Sentinel List Library updated to latest ver…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,5 @@ broadcast
 forge_cache/
 .gas-snapshot
 
+yarn-error.log
+yarn.lock

--- a/src/modular-etherspot-wallet/erc7579-ref-impl/libs/SentinelList.sol
+++ b/src/modular-etherspot-wallet/erc7579-ref-impl/libs/SentinelList.sol
@@ -1,4 +1,3 @@
-// https://github.com/zeroknots/sentinellist/
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
@@ -20,16 +19,11 @@ library SentinelListLib {
         self.entries[SENTINEL] = SENTINEL;
     }
 
-    function alreadyInitialized(
-        SentinelList storage self
-    ) internal view returns (bool) {
+    function alreadyInitialized(SentinelList storage self) internal view returns (bool) {
         return self.entries[SENTINEL] != ZERO_ADDRESS;
     }
 
-    function getNext(
-        SentinelList storage self,
-        address entry
-    ) internal view returns (address) {
+    function getNext(SentinelList storage self, address entry) internal view returns (address) {
         if (entry == ZERO_ADDRESS) {
             revert LinkedList_InvalidEntry(entry);
         }
@@ -40,30 +34,31 @@ library SentinelListLib {
         if (newEntry == ZERO_ADDRESS || newEntry == SENTINEL) {
             revert LinkedList_InvalidEntry(newEntry);
         }
-        if (self.entries[newEntry] != ZERO_ADDRESS)
-            revert LinkedList_EntryAlreadyInList(newEntry);
+        if (self.entries[newEntry] != ZERO_ADDRESS) revert LinkedList_EntryAlreadyInList(newEntry);
         self.entries[newEntry] = self.entries[SENTINEL];
         self.entries[SENTINEL] = newEntry;
     }
 
-    function pop(
-        SentinelList storage self,
-        address prevEntry,
-        address popEntry
-    ) internal {
+    function pop(SentinelList storage self, address prevEntry, address popEntry) internal {
         if (popEntry == ZERO_ADDRESS || popEntry == SENTINEL) {
             revert LinkedList_InvalidEntry(prevEntry);
         }
-        if (self.entries[prevEntry] != popEntry)
-            revert LinkedList_InvalidEntry(popEntry);
+        if (self.entries[prevEntry] != popEntry) revert LinkedList_InvalidEntry(popEntry);
         self.entries[prevEntry] = self.entries[popEntry];
         self.entries[popEntry] = ZERO_ADDRESS;
     }
 
-    function contains(
-        SentinelList storage self,
-        address entry
-    ) internal view returns (bool) {
+    function popAll(SentinelList storage self) internal {
+        address next = self.entries[SENTINEL];
+        while (next != ZERO_ADDRESS) {
+            address current = next;
+            next = self.entries[next];
+            self.entries[current] = ZERO_ADDRESS;
+        }
+        self.entries[SENTINEL] = ZERO_ADDRESS;
+    }
+
+    function contains(SentinelList storage self, address entry) internal view returns (bool) {
         return SENTINEL != entry && self.entries[entry] != ZERO_ADDRESS;
     }
 
@@ -71,9 +66,12 @@ library SentinelListLib {
         SentinelList storage self,
         address start,
         uint256 pageSize
-    ) internal view returns (address[] memory array, address next) {
-        if (start != SENTINEL && contains(self, start))
-            revert LinkedList_InvalidEntry(start);
+    )
+        internal
+        view
+        returns (address[] memory array, address next)
+    {
+        if (start != SENTINEL && !contains(self, start)) revert LinkedList_InvalidEntry(start);
         if (pageSize == 0) revert LinkedList_InvalidPage();
         // Init array with max page size
         array = new address[](pageSize);
@@ -81,23 +79,26 @@ library SentinelListLib {
         // Populate return array
         uint256 entryCount = 0;
         next = self.entries[start];
-        while (
-            next != ZERO_ADDRESS && next != SENTINEL && entryCount < pageSize
-        ) {
+        while (next != ZERO_ADDRESS && next != SENTINEL && entryCount < pageSize) {
             array[entryCount] = next;
             next = self.entries[next];
             entryCount++;
         }
 
         /**
-         * Because of the argument validation, we can assume that the loop will always iterate over the valid entry list values
-         *       and the `next` variable will either be an enabled entry or a sentinel address (signalling the end).
+         * Because of the argument validation, we can assume that the loop will always iterate over
+         * the valid entry list values
+         *       and the `next` variable will either be an enabled entry or a sentinel address
+         * (signalling the end).
          *
-         *       If we haven't reached the end inside the loop, we need to set the next pointer to the last element of the entry array
-         *       because the `next` variable (which is a entry by itself) acting as a pointer to the start of the next page is neither
-         *       incSENTINELrent page, nor will it be included in the next one if you pass it as a start.
+         *       If we haven't reached the end inside the loop, we need to set the next pointer to
+         * the last element of the entry array
+         *       because the `next` variable (which is a entry by itself) acting as a pointer to the
+         * start of the next page is neither
+         *       incSENTINELrent page, nor will it be included in the next one if you pass it as a
+         * start.
          */
-        if (next != SENTINEL) {
+        if (next != SENTINEL && entryCount > 0) {
             next = array[entryCount - 1];
         }
         // Set correct size of returned array


### PR DESCRIPTION
fix: pagination tests and Sentinel List Library updated to latest version

## Description
in Modular-etherspot-wallet, the reference implementation has a function to
paginate the executors (which is a sentinel list)
purpose is to use it to paginate the executors to get all executor addresses
like wise it has a pagination function for validators too

the existing pagination function has a bug:
1. The logic flaw here is that the condition incorrectly reverts when start is a valid entry in the list, which is the opposite of the intended behavior for pagination.
2. The correct behavior should allow the function to proceed when start is either the SENTINEL (indicating the start of the list) or any valid entry within the list.


## Motivation and Context
Change required to fix SentinelListLib pagination issue

## How Has This Been Tested?
forge Unit test to verify the pagination on SentinelListLib for Executors

## Types of changes
- [X ] Bug fix (non-breaking change which fixes an issue)
