### PR TITLE
Add event on smart account deployment

### DIFF
--- a/src/modular-etherspot-wallet/wallet/ModularEtherspotWalletFactory.sol
+++ b/src/modular-etherspot-wallet/wallet/ModularEtherspotWalletFactory.sol
@@ -7,6 +7,11 @@ import {IModularEtherspotWallet} from "../interfaces/IModularEtherspotWallet.sol
 contract ModularEtherspotWalletFactory {
     address public immutable implementation;
 
+    event ModularAccountDeployed(
+        address indexed account,
+        address indexed owner
+    );
+
     constructor(address _implementation) {
         implementation = _implementation;
     }
@@ -21,6 +26,7 @@ contract ModularEtherspotWalletFactory {
 
         if (!alreadyDeployed) {
             IModularEtherspotWallet(account).initializeAccount(initCode);
+            emit ModularAccountDeployed(account, msg.sender);
         }
         return account;
     }

--- a/test/foundry/wallet/ModularEtherspotWalletFactory.t.sol
+++ b/test/foundry/wallet/ModularEtherspotWalletFactory.t.sol
@@ -24,6 +24,11 @@ contract ModularEtherspotWalletFactoryTest is BootstrapUtil, Test {
     address owner1;
     uint256 owner1Key;
 
+    event ModularAccountDeployed(
+        address indexed account,
+        address indexed owner
+    );
+
     function setUp() public virtual {
         etchEntrypoint();
         implementation = new ModularEtherspotWallet();
@@ -180,5 +185,57 @@ contract ModularEtherspotWalletFactoryTest is BootstrapUtil, Test {
         );
         vm.stopPrank();
         assertFalse(address(account) == address(account2));
+    }
+
+    function test_emitEvent_createAccount() public {
+        // setup account init config
+        BootstrapConfig[] memory validators = makeBootstrapConfig(
+            address(defaultValidator),
+            ""
+        );
+        BootstrapConfig[] memory executors = makeBootstrapConfig(
+            address(defaultExecutor),
+            ""
+        );
+        BootstrapConfig memory hook = _makeBootstrapConfig(address(0), "");
+        BootstrapConfig[] memory fallbacks = makeBootstrapConfig(
+            address(0),
+            ""
+        );
+
+        bytes memory initCode = abi.encode(
+            owner1,
+            address(bootstrapSingleton),
+            abi.encodeCall(
+                Bootstrap.initMSA,
+                (validators, executors, hook, fallbacks)
+            )
+        );
+
+        vm.startPrank(owner1);
+        address expectedAddress = factory.getAddress({
+            salt: SALT,
+            initcode: initCode
+        });
+
+        // emit event
+        vm.expectEmit(true, true, true, true);
+        emit ModularAccountDeployed(expectedAddress, owner1);
+        // create account
+        account = ModularEtherspotWallet(
+            payable(factory.createAccount({salt: SALT, initCode: initCode}))
+        );
+        assertEq(
+            address(account),
+            expectedAddress,
+            "Computed wallet address should always equal wallet address created"
+        );
+        // should not emit event if address already exists
+        // checked using -vvvv stack trace
+        account = ModularEtherspotWallet(
+            payable(factory.createAccount({salt: SALT, initCode: initCode}))
+        );
+
+        vm.stopPrank();
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Added `ModularAccountDeployed` event emit only on new smart account deployment.
- Added test to check event emission.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- To allow for tracking of new smart wallets.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Tested event emit locally in suite.

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/ffd8a006-074d-4e91-9fa6-74e7d2b2fd07)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
