### PR TITLE
feat: TokenLockSessionKeyValidator enhanced to support multiple token…

### DIFF
--- a/src/modular-etherspot-wallet/interfaces/ITokenLockSessionKeyValidator.sol
+++ b/src/modular-etherspot-wallet/interfaces/ITokenLockSessionKeyValidator.sol
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import {IValidator} from "../../../src/modular-etherspot-wallet/erc7579-ref-impl/interfaces/IERC7579Module.sol";
+import {IERC7579Account} from "../../../src/modular-etherspot-wallet/erc7579-ref-impl/interfaces/IERC7579Account.sol";
+import {PackedUserOperation} from "../../../account-abstraction/contracts/interfaces/PackedUserOperation.sol";
+
+/// @title TokenSessionKeyValidator Interface
+/// @author Etherspot
+/// @notice This interface defines the functions and events of the TokenSessionKeyValidator contract.
+interface ITokenLockSessionKeyValidator is IValidator {
+    /// @notice Emitted when the ERC20 Session Key Validator module is installed for a wallet.
+    /// @param wallet The address of the wallet for which the module is installed.
+    event ERC20SKV_ModuleInstalled(address wallet);
+
+    /// @notice Emitted when the ERC20 Session Key Validator module is uninstalled from a wallet.
+    /// @param wallet The address of the wallet from which the module is uninstalled.
+    event ERC20SKV_ModuleUninstalled(address wallet);
+
+    /// @notice Emitted when a new session key is enabled for a wallet.
+    /// @param sessionKey The address of the session key.
+    /// @param wallet The address of the wallet for which the session key is enabled.
+    event ERC20SKV_SessionKeyEnabled(address sessionKey, address wallet);
+
+    /// @notice Emitted when a session key is disabled for a wallet.
+    /// @param sessionKey The address of the session key.
+    /// @param wallet The address of the wallet for which the session key is disabled.
+    event ERC20SKV_SessionKeyDisabled(address sessionKey, address wallet);
+
+    /// @notice Emitted when a session key is paused for a wallet.
+    /// @param sessionKey The address of the session key.
+    /// @param wallet The address of the wallet for which the session key is paused.
+    event ERC20SKV_SessionKeyPaused(address sessionKey, address wallet);
+
+    /// @notice Emitted when a session key is unpaused for a wallet.
+    /// @param sessionKey The address of the session key.
+    /// @param wallet The address of the wallet for which the session key is unpaused.
+    event ERC20SKV_SessionKeyUnpaused(address sessionKey, address wallet);
+
+    /// @notice Struct representing the data associated with a session key.
+    struct SessionData {
+        address[] tokens; // The array of ERC20 token contract addresses.
+        bytes4 funcSelector; // The function selector for the allowed operation (e.g., transfer, transferFrom).
+        uint256[] amounts; // The array of lockedAmounts that has been locked for this session key.
+        address solverAddress; // The address of the solver.
+        uint48 validAfter; // The timestamp after which the session key is valid.
+        uint48 validUntil; // The timestamp until which the session key is valid.
+        bool live; // Flag indicating whether the session key is paused or not.
+    }
+
+    /// @notice Enables a new session key for the caller's wallet.
+    /// @param _sessionData The encoded session data containing the session key address, token address, interface ID, function selector, spending limit, valid after timestamp, and valid until timestamp.
+    function enableSessionKey(bytes calldata _sessionData) external;
+
+    /// @notice Disables a session key for the caller's wallet.
+    /// @param _session The address of the session key to disable.
+    function disableSessionKey(address _session) external;
+
+    /// @notice Rotates a session key by disabling the old one and enabling a new one.
+    /// @param _oldSessionKey The address of the old session key to disable.
+    /// @param _newSessionData The encoded session data for the new session key.
+    function rotateSessionKey(
+        address _oldSessionKey,
+        bytes calldata _newSessionData
+    ) external;
+
+    /// @notice Toggles the pause state of a session key for the caller's wallet.
+    /// @param _sessionKey The address of the session key to toggle the pause state for.
+    function toggleSessionKeyPause(address _sessionKey) external;
+
+    /// @notice Checks if a session key is paused for the caller's wallet.
+    /// @param _sessionKey The address of the session key to check.
+    /// @return paused True if the session key is paused, false otherwise.
+    function isSessionKeyLive(
+        address _sessionKey
+    ) external view returns (bool paused);
+
+    /// @notice Validates the parameters of a session key for a given user operation.
+    /// @param _sessionKey The address of the session key.
+    /// @param userOp The packed user operation containing the call data.
+    /// @return True if the session key parameters are valid for the user operation, false otherwise.
+    function validateSessionKeyParams(
+        address _sessionKey,
+        PackedUserOperation calldata userOp
+    ) external returns (bool);
+
+    /// @notice Returns the list of associated session keys for the caller's wallet.
+    /// @return keys The array of associated session key addresses.
+    function getAssociatedSessionKeys()
+        external
+        view
+        returns (address[] memory keys);
+
+    /// @notice Returns the session data for a given session key and the caller's wallet.
+    /// @param _sessionKey The address of the session key.
+    /// @return data The session data struct.
+    function getSessionKeyData(
+        address _sessionKey
+    ) external view returns (SessionData memory data);
+
+    /// @notice Validates a user operation using a session key.
+    /// @param userOp The packed user operation.
+    /// @param userOpHash The hash of the user operation.
+    /// @return validationData The validation data containing the expiration time and valid after timestamp of the session key.
+    function validateUserOp(
+        PackedUserOperation calldata userOp,
+        bytes32 userOpHash
+    ) external returns (uint256 validationData);
+
+    /// @notice Checks if the module type matches the validator module type.
+    /// @param moduleTypeId The module type ID to check.
+    /// @return True if the module type matches the validator module type, false otherwise.
+    function isModuleType(uint256 moduleTypeId) external pure returns (bool);
+
+    /// @notice Placeholder function for module installation.
+    /// @param data The data to pass during installation.
+    function onInstall(bytes calldata data) external;
+
+    /// @notice Placeholder function for module uninstallation.
+    /// @param data The data to pass during uninstallation.
+    function onUninstall(bytes calldata data) external;
+
+    /// @notice Reverts with a "NotImplemented" error.
+    /// @param sender The address of the sender.
+    /// @param hash The hash of the message.
+    /// @param data The data associated with the message.
+    /// @return A bytes4 value indicating the function is not implemented.
+    function isValidSignatureWithSender(
+        address sender,
+        bytes32 hash,
+        bytes calldata data
+    ) external view returns (bytes4);
+
+    /// @notice Reverts with a "NotImplemented" error.
+    /// @param smartAccount The address of the smart account.
+    /// @return True if the smart account is initialized, false otherwise.
+    function isInitialized(address smartAccount) external view returns (bool);
+}

--- a/src/modular-etherspot-wallet/interfaces/ITokenLockSessionKeyValidator.sol
+++ b/src/modular-etherspot-wallet/interfaces/ITokenLockSessionKeyValidator.sol
@@ -11,31 +11,31 @@ import {PackedUserOperation} from "../../../account-abstraction/contracts/interf
 interface ITokenLockSessionKeyValidator is IValidator {
     /// @notice Emitted when the ERC20 Session Key Validator module is installed for a wallet.
     /// @param wallet The address of the wallet for which the module is installed.
-    event ERC20SKV_ModuleInstalled(address wallet);
+    event TLSKV_ModuleInstalled(address wallet);
 
     /// @notice Emitted when the ERC20 Session Key Validator module is uninstalled from a wallet.
     /// @param wallet The address of the wallet from which the module is uninstalled.
-    event ERC20SKV_ModuleUninstalled(address wallet);
+    event TLSKV_ModuleUninstalled(address wallet);
 
     /// @notice Emitted when a new session key is enabled for a wallet.
     /// @param sessionKey The address of the session key.
     /// @param wallet The address of the wallet for which the session key is enabled.
-    event ERC20SKV_SessionKeyEnabled(address sessionKey, address wallet);
+    event TLSKV_SessionKeyEnabled(address sessionKey, address wallet);
 
     /// @notice Emitted when a session key is disabled for a wallet.
     /// @param sessionKey The address of the session key.
     /// @param wallet The address of the wallet for which the session key is disabled.
-    event ERC20SKV_SessionKeyDisabled(address sessionKey, address wallet);
+    event TLSKV_SessionKeyDisabled(address sessionKey, address wallet);
 
     /// @notice Emitted when a session key is paused for a wallet.
     /// @param sessionKey The address of the session key.
     /// @param wallet The address of the wallet for which the session key is paused.
-    event ERC20SKV_SessionKeyPaused(address sessionKey, address wallet);
+    event TLSKV_SessionKeyPaused(address sessionKey, address wallet);
 
     /// @notice Emitted when a session key is unpaused for a wallet.
     /// @param sessionKey The address of the session key.
     /// @param wallet The address of the wallet for which the session key is unpaused.
-    event ERC20SKV_SessionKeyUnpaused(address sessionKey, address wallet);
+    event TLSKV_SessionKeyUnpaused(address sessionKey, address wallet);
 
     /// @notice Struct representing the data associated with a session key.
     struct SessionData {

--- a/src/modular-etherspot-wallet/modules/hooks/TokenLockHook.sol
+++ b/src/modular-etherspot-wallet/modules/hooks/TokenLockHook.sol
@@ -121,7 +121,7 @@ contract TokenLockHook is IHook {
         ModeCode mode = ModeCode.wrap(bytes32(msgData[4:36]));
         (CallType callType, , ModeSelector modeSelector, ) = mode.decode();
         if (eqModeSelector(modeSelector, MODE_SELECTOR_MTSKV)) {
-            _handleMultiTokenSessionKeyValidator(callType, msgData[100:]);
+            _handleTokenLockSessionKeyValidator(callType, msgData[100:]);
         } else {
             return _checkLockedTokens(callType, msgData[100:]);
         }
@@ -166,7 +166,7 @@ contract TokenLockHook is IHook {
     // rather than current approach of locking tokens on
     // erc20 transfer or transferFrom call from MultiTokenSessionKeyValidator
     // TODO: decide on data passed into enableSesionKey
-    function _handleMultiTokenSessionKeyValidator(
+    function _handleTokenLockSessionKeyValidator(
         CallType _callType,
         bytes calldata _executionData
     ) internal {

--- a/src/modular-etherspot-wallet/modules/validators/TokenLockSessionKeyValidator.sol
+++ b/src/modular-etherspot-wallet/modules/validators/TokenLockSessionKeyValidator.sol
@@ -11,6 +11,7 @@ import "../../erc7579-ref-impl/libs/ModeLib.sol";
 import "../../erc7579-ref-impl/libs/ExecutionLib.sol";
 import {ITokenLockSessionKeyValidator} from "../../interfaces/ITokenLockSessionKeyValidator.sol";
 import {ArrayLib} from "../../libraries/ArrayLib.sol";
+import "forge-std/console.sol";
 
 contract TokenLockSessionKeyValidator is ITokenLockSessionKeyValidator {
     using ModeLib for ModeCode;
@@ -27,17 +28,18 @@ contract TokenLockSessionKeyValidator is ITokenLockSessionKeyValidator {
     /*                    ERRORS                 */
     /*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*/
 
-    error ERC20SKV_ModuleAlreadyInstalled();
-    error ERC20SKV_ModuleNotInstalled();
-    error ERC20SKV_InvalidSessionKey();
-    error ERC20SKV_InvalidToken();
-    error ERC20SKV_InvalidFunctionSelector();
-    error ERC20SKV_InvalidSpendingLimit();
-    error ERC20SKV_InvalidValidAfter(uint48 validAfter);
-    error ERC20SKV_InvalidValidUntil(uint48 validUntil);
-    error ERC20SKV_SessionKeyAlreadyExists(address sessionKey);
-    error ERC20SKV_SessionKeyDoesNotExist(address session);
-    error ERC20SKV_SessionPaused(address sessionKey);
+    error TLSKV_ModuleAlreadyInstalled();
+    error TLSKV_ModuleNotInstalled();
+    error TLSKV_InvalidSessionKey();
+    error TLSKV_InvalidToken();
+    error TLSKV_InvalidFunctionSelector();
+    error TLSKV_InvalidSpendingLimit();
+    error TLSKV_InvalidValidAfter(uint48 validAfter);
+    error TLSKV_InvalidValidUntil(uint48 validUntil);
+    error TLSKV_InvalidTokenAmountData(address sessionKey);
+    error TLSKV_SessionKeyAlreadyExists(address sessionKey);
+    error TLSKV_SessionKeyDoesNotExist(address session);
+    error TLSKV_SessionPaused(address sessionKey);
     error NotImplemented();
 
     /*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*/
@@ -50,74 +52,87 @@ contract TokenLockSessionKeyValidator is ITokenLockSessionKeyValidator {
     mapping(address sessionKey => mapping(address wallet => SessionData))
         public sessionData;
 
+    struct ExecData {
+        bytes4 selector;
+        address from;
+        address to;
+        uint256 amount;
+    }
+
+
     /*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*/
     /*               PUBLIC/EXTERNAL             */
     /*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*/
 
-    // @inheritdoc IERC20SessionKeyValidator
+    // @inheritdoc ITokenLockSessionKeyValidator
     function enableSessionKey(bytes calldata _sessionData) public {
         uint256 offset = 0;
 
         address sessionKey = address(bytes20(_sessionData[offset:offset + 20]));
         offset += 20;
-        if (sessionKey == address(0)) revert ERC20SKV_InvalidSessionKey();
+        if (sessionKey == address(0)) revert TLSKV_InvalidSessionKey();
+
+        address solverAddress = address(bytes20(_sessionData[offset:offset + 20]));
+        offset += 20;
+
+        bytes4 funcSelector = bytes4(_sessionData[offset:offset + 4]);
+        offset += 4;
+        if (funcSelector == bytes4(0)) revert TLSKV_InvalidFunctionSelector();
+
+        uint48 validAfter = uint48(bytes6(_sessionData[offset:offset + 6]));
+        offset += 6;
+        if (validAfter == 0) revert TLSKV_InvalidValidAfter(validAfter);
+
+        uint48 validUntil = uint48(bytes6(_sessionData[offset:offset + 6]));
+        offset += 6;
+        if (validUntil == 0) revert TLSKV_InvalidValidUntil(validUntil);
 
         uint256 tokensLength = uint256(bytes32(_sessionData[offset:offset + 32]));
         offset += 32;
 
         address[] memory tokens = new address[](tokensLength);
         for (uint256 i = 0; i < tokensLength; i++) {
-            tokens[i] = address(bytes20(_sessionData[offset:offset + 20]));
-            offset += 20;
+            tokens[i] = address(uint160(uint256(bytes32(_sessionData[offset:offset + 32]))));
+            offset += 32;
         }
-
-        bytes4 funcSelector = bytes4(_sessionData[offset:offset + 4]);
-        offset += 4;
-        if (funcSelector == bytes4(0)) revert ERC20SKV_InvalidFunctionSelector();
 
         uint256 amountsLength = uint256(bytes32(_sessionData[offset:offset + 32]));
         offset += 32;
 
+        // Decode amounts array
         uint256[] memory amounts = new uint256[](amountsLength);
         for (uint256 i = 0; i < amountsLength; i++) {
             amounts[i] = uint256(bytes32(_sessionData[offset:offset + 32]));
             offset += 32;
         }
 
-        address solverAddress = address(bytes20(_sessionData[offset:offset + 20]));
-        offset += 20;
+        if(tokensLength != amountsLength) revert TLSKV_InvalidTokenAmountData(sessionKey);  
 
-        uint48 validUntil = uint48(uint256(bytes32(_sessionData[offset:offset + 6])));
-        offset += 6;
-        if (validUntil == 0) revert ERC20SKV_InvalidValidUntil(validUntil);
-
-        uint48 validAfter = uint48(uint256(bytes32(_sessionData[offset:offset + 6])));
-        offset += 6;
-        if (validAfter == 0) revert ERC20SKV_InvalidValidAfter(validAfter);
-
+        // Store the decoded data in sessionData mapping
         sessionData[sessionKey][msg.sender] = SessionData(
             tokens,
             funcSelector,
             amounts,
             solverAddress,
-            validUntil,
             validAfter,
+            validUntil,
             true
         );
+
         walletSessionKeys[msg.sender].push(sessionKey);
-        emit ERC20SKV_SessionKeyEnabled(sessionKey, msg.sender);
+        emit TLSKV_SessionKeyEnabled(sessionKey, msg.sender);
     }
 
     // @inheritdoc IERC20SessionKeyValidator
     function disableSessionKey(address _session) public {
         if (sessionData[_session][msg.sender].validUntil == 0)
-            revert ERC20SKV_SessionKeyDoesNotExist(_session);
+            revert TLSKV_SessionKeyDoesNotExist(_session);
         delete sessionData[_session][msg.sender];
         walletSessionKeys[msg.sender] = ArrayLib._removeElement(
             getAssociatedSessionKeys(),
             _session
         );
-        emit ERC20SKV_SessionKeyDisabled(_session, msg.sender);
+        emit TLSKV_SessionKeyDisabled(_session, msg.sender);
     }
 
     // @inheritdoc IERC20SessionKeyValidator
@@ -133,13 +148,13 @@ contract TokenLockSessionKeyValidator is ITokenLockSessionKeyValidator {
     function toggleSessionKeyPause(address _sessionKey) external {
         SessionData storage sd = sessionData[_sessionKey][msg.sender];
         if (sd.validUntil == 0)
-            revert ERC20SKV_SessionKeyDoesNotExist(_sessionKey);
+            revert TLSKV_SessionKeyDoesNotExist(_sessionKey);
         if (sd.live) {
             sd.live = false;
-            emit ERC20SKV_SessionKeyPaused(_sessionKey, msg.sender);
+            emit TLSKV_SessionKeyPaused(_sessionKey, msg.sender);
         } else {
             sd.live = true;
-            emit ERC20SKV_SessionKeyUnpaused(_sessionKey, msg.sender);
+            emit TLSKV_SessionKeyUnpaused(_sessionKey, msg.sender);
         }
     }
 
@@ -154,83 +169,19 @@ contract TokenLockSessionKeyValidator is ITokenLockSessionKeyValidator {
         PackedUserOperation calldata userOp
     ) public view returns (bool) {
         SessionData memory sd = sessionData[_sessionKey][msg.sender];
-        if (isSessionKeyLive(_sessionKey) == false) {
+        if (!isSessionKeyLive(_sessionKey)) {
             return false;
         }
-        address target;
+
         bytes calldata callData = userOp.callData;
-        bytes4 sel = bytes4(callData[:4]);
-        if (sel == IERC7579Account.execute.selector) {
+        if (bytes4(callData[:4]) == IERC7579Account.execute.selector) {
             ModeCode mode = ModeCode.wrap(bytes32(callData[4:36]));
             (CallType calltype, , , ) = ModeLib.decode(mode);
+
             if (calltype == CALLTYPE_SINGLE) {
-                bytes calldata execData;
-                // 0x00 ~ 0x04 : selector
-                // 0x04 ~ 0x24 : mode code
-                // 0x24 ~ 0x44 : execution target
-                // 0x44 ~0x64 : execution value
-                // 0x64 ~ : execution calldata
-                (target, , execData) = ExecutionLib.decodeSingle(
-                    callData[100:]
-                );
-                (
-                    bytes4 selector,
-                    address from,
-                    address to,
-                    uint256 amount
-                ) = _digest(execData);
-
-                if (selector != sd.funcSelector) return false;
-
-                bool tokenFound = false;
-                uint256 tokenIndex = 0;
-                for (uint256 i = 0; i < sd.tokens.length; i++) {
-                    if (sd.tokens[i] == target) {
-                        tokenFound = true;
-                        tokenIndex = i;
-                        break;
-                    }
-                }
-                if (!tokenFound) return false;
-
-                if (! (amount == sd.amounts[tokenIndex])) return false;
-
-                // validate if wallet has sufficient balance
-                if (selector == IERC20.transfer.selector) {
-                    if (IERC20(target).balanceOf(from) < amount) return false;
-                } else if (selector == IERC20.transferFrom.selector) {
-                    if (IERC20(target).allowance(from, to) < amount) return false;
-                }
-
-                return true;
-            }
-            if (calltype == CALLTYPE_BATCH) {
-                Execution[] calldata execs = ExecutionLib.decodeBatch(
-                    callData[100:]
-                );
-                for (uint256 i; i < execs.length; i++) {
-                    target = execs[i].target;
-                    (
-                        bytes4 selector,
-                        address from,
-                        address to,
-                        uint256 amount
-                    ) = _digest(execs[i].callData);
-                    if (selector != sd.funcSelector) return false;
-                    bool tokenFound = false;
-                    uint256 tokenIndex = 0;
-                    for (uint256 j = 0; j < sd.tokens.length; j++) {
-                        if (sd.tokens[j] == target) {
-                            tokenFound = true;
-                            tokenIndex = j;
-                            break;
-                        }
-                    }
-                    if (!tokenFound) return false;
-
-                    if (!(amount == sd.amounts[tokenIndex])) return false;
-                }
-                return true;
+                return validateSingleCall(callData, sd, userOp.sender);
+            } else if (calltype == CALLTYPE_BATCH) {
+                return validateBatchCall(callData, sd, userOp.sender);
             } else {
                 return false;
             }
@@ -238,6 +189,77 @@ contract TokenLockSessionKeyValidator is ITokenLockSessionKeyValidator {
             return false;
         }
     }
+
+    function validateSingleCall(
+        bytes calldata callData,
+        SessionData memory sd,
+        address userOpSender
+    ) internal view returns (bool) {
+        address target;
+        bytes calldata execData;
+        (target, , execData) = ExecutionLib.decodeSingle(callData[100:]);
+
+        (bytes4 selector, address from, , uint256 amount) = _digest(execData);
+
+        if (selector != sd.funcSelector) return false;
+        return validateTokenData(sd.tokens, selector, userOpSender, from, amount, target);
+    }
+
+    // Internal function to validate batch call
+    function validateBatchCall(
+        bytes calldata callData,
+        SessionData memory sd,
+        address userOpSender
+    ) internal view returns (bool) {
+        Execution[] calldata execs = ExecutionLib.decodeBatch(callData[100:]);
+        for (uint256 i; i < execs.length; i++) {
+            address target = execs[i].target;
+            (bytes4 selector, address from, , uint256 amount) = _digest(execs[i].callData);
+            if (selector != sd.funcSelector) return false;
+            if (!validateTokenData(sd.tokens, selector, userOpSender, from, amount, target)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    function validateTokenData(
+        address[] memory tokens,
+        bytes4 selector,
+        address userOpSender,
+        address from,
+        uint256 amount,
+        address token
+    ) internal view returns (bool) {
+
+        (bool tokenFound, ) = findTokenIndex(tokens, token);
+
+        if (!tokenFound) return false;
+
+        // Validate if wallet has sufficient balance
+        if (selector == IERC20.transfer.selector) {
+            if (IERC20(token).balanceOf(from) < amount) {
+                return false;
+            }
+        } else if (selector == IERC20.transferFrom.selector) {
+            if (IERC20(token).balanceOf(userOpSender) < amount || IERC20(token).allowance(userOpSender, from) < amount) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+
+    function findTokenIndex(address[] memory tokens, address target) internal pure returns (bool, uint256) {
+        for (uint256 i = 0; i < tokens.length; i++) {
+            if (tokens[i] == target) {
+                return (true, i);
+            }
+        }
+        return (false, 0);
+    }
+
 
     // @inheritdoc IERC20SessionKeyValidator
     function getAssociatedSessionKeys() public view returns (address[] memory) {
@@ -260,15 +282,16 @@ contract TokenLockSessionKeyValidator is ITokenLockSessionKeyValidator {
             ECDSA.toEthSignedMessageHash(userOpHash),
             userOp.signature
         );
-        if (!validateSessionKeyParams(sessionKeySigner, userOp))
+        if (!validateSessionKeyParams(sessionKeySigner, userOp)) {
             return VALIDATION_FAILED;
+        }
+        
         SessionData memory sd = sessionData[sessionKeySigner][msg.sender];
 
         //disable SessionKey
         //disable is run because the SessioneKey is only valid for one operation
         //once used it should be disabled
         disableSessionKey(sessionKeySigner);
-
         return _packValidationData(false, sd.validUntil, sd.validAfter);
     }
 
@@ -282,15 +305,15 @@ contract TokenLockSessionKeyValidator is ITokenLockSessionKeyValidator {
     // @inheritdoc IERC20SessionKeyValidator
     function onInstall(bytes calldata data) external override {
         if (initialized[msg.sender] == true)
-            revert ERC20SKV_ModuleAlreadyInstalled();
+            revert TLSKV_ModuleAlreadyInstalled();
         initialized[msg.sender] = true;
-        emit ERC20SKV_ModuleInstalled(msg.sender);
+        emit TLSKV_ModuleInstalled(msg.sender);
     }
 
     // @inheritdoc IERC20SessionKeyValidator
     function onUninstall(bytes calldata data) external override {
         if (initialized[msg.sender] == false)
-            revert ERC20SKV_ModuleNotInstalled();
+            revert TLSKV_ModuleNotInstalled();
         address[] memory sessionKeys = getAssociatedSessionKeys();
         uint256 sessionKeysLength = sessionKeys.length;
         for (uint256 i; i < sessionKeysLength; i++) {
@@ -298,7 +321,7 @@ contract TokenLockSessionKeyValidator is ITokenLockSessionKeyValidator {
         }
         delete walletSessionKeys[msg.sender];
         initialized[msg.sender] = false;
-        emit ERC20SKV_ModuleUninstalled(msg.sender);
+        emit TLSKV_ModuleUninstalled(msg.sender);
     }
 
     // @inheritdoc IERC20SessionKeyValidator

--- a/src/modular-etherspot-wallet/modules/validators/TokenLockSessionKeyValidator.sol
+++ b/src/modular-etherspot-wallet/modules/validators/TokenLockSessionKeyValidator.sol
@@ -11,7 +11,6 @@ import "../../erc7579-ref-impl/libs/ModeLib.sol";
 import "../../erc7579-ref-impl/libs/ExecutionLib.sol";
 import {ITokenLockSessionKeyValidator} from "../../interfaces/ITokenLockSessionKeyValidator.sol";
 import {ArrayLib} from "../../libraries/ArrayLib.sol";
-import "forge-std/console.sol";
 
 contract TokenLockSessionKeyValidator is ITokenLockSessionKeyValidator {
     using ModeLib for ModeCode;

--- a/src/modular-etherspot-wallet/modules/validators/TokenLockSessionKeyValidator.sol
+++ b/src/modular-etherspot-wallet/modules/validators/TokenLockSessionKeyValidator.sol
@@ -287,10 +287,6 @@ contract TokenLockSessionKeyValidator is ITokenLockSessionKeyValidator {
         
         SessionData memory sd = sessionData[sessionKeySigner][msg.sender];
 
-        //disable SessionKey
-        //disable is run because the SessioneKey is only valid for one operation
-        //once used it should be disabled
-        disableSessionKey(sessionKeySigner);
         return _packValidationData(false, sd.validUntil, sd.validAfter);
     }
 

--- a/src/modular-etherspot-wallet/test/TestDAI.sol
+++ b/src/modular-etherspot-wallet/test/TestDAI.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.23;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract TestDAI is ERC20 {
+    constructor() ERC20("TDAI", "TestDAI") {}
+
+    function mint(address sender, uint256 amount) external {
+        _mint(sender, amount);
+    }
+
+    function decimals() public pure override returns (uint8) {
+        return 18;
+    }
+}

--- a/src/modular-etherspot-wallet/test/TestUNI.sol
+++ b/src/modular-etherspot-wallet/test/TestUNI.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.23;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract TestUNI is ERC20 {
+    constructor() ERC20("TUNI", "TestUNI") {}
+
+    function mint(address sender, uint256 amount) external {
+        _mint(sender, amount);
+    }
+
+    function decimals() public pure override returns (uint8) {
+        return 18;
+    }
+}

--- a/test/foundry/harnesses/TokenLockHookHarness.sol
+++ b/test/foundry/harnesses/TokenLockHookHarness.sol
@@ -5,15 +5,15 @@ import {TokenLockHook} from "../../../src/modular-etherspot-wallet/modules/hooks
 import "../../../src/modular-etherspot-wallet/erc7579-ref-impl/libs/ModeLib.sol";
 
 contract TokenLockHookHarness is TokenLockHook {
-    function exposed_lockToken(address _token, uint256 _amount) external {
-        return _lockToken(_token, _amount);
+    function exposed_lockToken(address _sessionKey, address _solver, address _token, uint256 _amount) external {
+        return _lockToken(_sessionKey, _solver, _token, _amount);
     }
 
     function exposed_handleMultiTokenSessionKeyValidator(
         CallType _callType,
         bytes calldata _executionData
     ) external {
-        return _handleMultiTokenSessionKeyValidator(_callType, _executionData);
+        return _handleTokenLockSessionKeyValidator(_callType, _executionData);
     }
 
     function exposed_checkLockedTokens(

--- a/test/foundry/modules/TokenLockHook/concrete/TokenLockHook.t.sol
+++ b/test/foundry/modules/TokenLockHook/concrete/TokenLockHook.t.sol
@@ -282,8 +282,8 @@ contract TokenLockHook_Concrete_Test is TokenLockHookTestUtils {
         // Check receiver balance
         assertEq(erc20.balanceOf(address(receiver)), 1 ether);
         assertEq(newErc20.balanceOf(address(receiver)), 2 ether);
-        assertTrue(tokenLockHook.isTokenLocked(address(erc20)));
-        assertTrue(tokenLockHook.isTokenLocked(address(newErc20)));
+        assertTrue(tokenLockHook.isTokenLocked(address(mew), address(erc20)));
+        assertTrue(tokenLockHook.isTokenLocked(address(mew), address(newErc20)));
         assertTrue(tokenLockHook.isTransactionInProgress());
     }
 
@@ -358,7 +358,7 @@ contract TokenLockHook_Concrete_Test is TokenLockHookTestUtils {
         // Check receiver balance
         assertEq(erc20.balanceOf(address(receiver)), 1 ether);
         // Check tokens are not locked
-        assertFalse(tokenLockHook.isTokenLocked(address(erc20)));
+        assertFalse(tokenLockHook.isTokenLocked(address(mew), address(erc20)));
     }
 
     function test_preCheck_ifOtherValidator_RevertIf_tokensAreLocked() public {
@@ -461,7 +461,7 @@ contract TokenLockHook_Concrete_Test is TokenLockHookTestUtils {
         // Execute the lockToken function
         harness.exposed_lockToken(token, amount);
         // Check that the token is locked
-        assertTrue(harness.isTokenLocked(token));
+        assertTrue(harness.isTokenLocked(address(mew), token));
     }
 
     function test_exposed_lockToken_RevertIf_tokenAlreadyLocked() public {
@@ -512,7 +512,7 @@ contract TokenLockHook_Concrete_Test is TokenLockHookTestUtils {
             execution
         );
         // Check that the token is locked
-        assertTrue(harness.isTokenLocked(address(erc20)));
+        assertTrue(harness.isTokenLocked(address(mew), address(erc20)));
     }
 
     function test_exposed_handleMultiTokenSessionKeyValidator_callTypeBatch()
@@ -553,8 +553,8 @@ contract TokenLockHook_Concrete_Test is TokenLockHookTestUtils {
             batchExecutions
         );
         // Check that the Tokens are locked
-        assertTrue(harness.isTokenLocked(address(erc20)));
-        assertTrue(harness.isTokenLocked(address(newERC20)));
+        assertTrue(harness.isTokenLocked(address(mew), address(erc20)));
+        assertTrue(harness.isTokenLocked(address(mew), address(newERC20)));
     }
 
     function test_exposed_handleMultiTokenSessionKeyValidator_RevertIf_invalidCallType()
@@ -589,7 +589,7 @@ contract TokenLockHook_Concrete_Test is TokenLockHookTestUtils {
             execution
         );
         // Check that the token is not locked
-        assertFalse(harness.isTokenLocked(address(erc20)));
+        assertFalse(harness.isTokenLocked(address(mew), address(erc20)));
     }
 
     function test_exposed_handleMultiTokenSessionKeyValidator_RevertIf_doubleLockingTokenInBatch()
@@ -632,7 +632,7 @@ contract TokenLockHook_Concrete_Test is TokenLockHookTestUtils {
             batchExecutions
         );
         // Check that the token is not locked
-        assertFalse(harness.isTokenLocked(address(erc20)));
+        assertFalse(harness.isTokenLocked(address(mew), address(erc20)));
     }
 
     function test_exposed_checkLockedTokens_RevertIf_invalidCallType() public {
@@ -726,9 +726,9 @@ contract TokenLockHook_Concrete_Test is TokenLockHookTestUtils {
         );
         bytes memory batchExecutions = ExecutionLib.encodeBatch(batchCall);
         // Lock one of the tokens
-        harness.exposed_lockToken(address(erc20), 1);
+        harness.exposed_lockToken(receiver, address(erc20), 1);
         // Check that the locked token is locked
-        assertTrue(harness.isTokenLocked(address(erc20)));
+        assertTrue(harness.isTokenLocked(address(mew), address(erc20)));
         // Expect the function call to revert with TLH_TransactionInProgress error
         // if one of the Tokens is locked
         vm.expectRevert(
@@ -741,9 +741,9 @@ contract TokenLockHook_Concrete_Test is TokenLockHookTestUtils {
         // Execute the checkLockedTokens function
         harness.exposed_checkLockedTokens(callType, batchExecutions);
         // Check that the locked token is still locked
-        assertTrue(harness.isTokenLocked(address(erc20)));
+        assertTrue(harness.isTokenLocked(address(mew), address(erc20)));
         // Check that the other token is not locked
-        assertFalse(harness.isTokenLocked(address(newERC20)));
+        assertFalse(harness.isTokenLocked(address(mew), address(newERC20)));
     }
 
     function test_exposed_getTokenAmount_transfer() public {

--- a/test/foundry/modules/TokenLockSessionKeyValidator.t.sol
+++ b/test/foundry/modules/TokenLockSessionKeyValidator.t.sol
@@ -501,12 +501,5 @@ contract TokenLockSessionKeyValidatorTest is TestAdvancedUtils {
 
         entrypoint.handleOps(userOps, beneficiary);
         assertEq(usdc.balanceOf(address(bob)), amounts[0]);
-
-        // assert the disabled session key
-        assertEq(tokenLockSessionKeyValidator.getAssociatedSessionKeys().length, 0);
-        assertEq(tokenLockSessionKeyValidator.getSessionKeyData(sessionKey).validUntil, 0);
-        assertEq(tokenLockSessionKeyValidator.getSessionKeyData(sessionKey).funcSelector, bytes4(0));
-        assertEq(tokenLockSessionKeyValidator.getSessionKeyData(sessionKey).tokens.length, 0);
-        assertEq(tokenLockSessionKeyValidator.getSessionKeyData(sessionKey).amounts.length, 0);
     }
 }

--- a/test/foundry/modules/TokenLockSessionKeyValidator.t.sol
+++ b/test/foundry/modules/TokenLockSessionKeyValidator.t.sol
@@ -1,0 +1,344 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "forge-std/Test.sol";
+import "../../../src/modular-etherspot-wallet/modules/validators/TokenLockSessionKeyValidator.sol";
+import "../../../src/modular-etherspot-wallet/wallet/ModularEtherspotWallet.sol";
+import "../../../src/modular-etherspot-wallet/test/TestERC20.sol";
+import "../../../src/modular-etherspot-wallet/test/TestUSDC.sol";
+import "../../../src/modular-etherspot-wallet/test/TestDAI.sol";
+import "../../../src/modular-etherspot-wallet/test/TestUNI.sol";
+import {PackedUserOperation} from "../../../account-abstraction/contracts/interfaces/PackedUserOperation.sol";
+import {VALIDATION_FAILED} from "../../../src/modular-etherspot-wallet/erc7579-ref-impl/interfaces/IERC7579Module.sol";
+import "../TestAdvancedUtils.t.sol";
+import "../../../src/modular-etherspot-wallet/utils/ERC4337Utils.sol";
+
+using ERC4337Utils for IEntryPoint;
+
+contract TokenLockSessionKeyValidatorTest is TestAdvancedUtils {
+    using ECDSA for bytes32;
+
+    /*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*/
+    /*                  VARIABLES               */
+    /*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*/
+
+    ModularEtherspotWallet mew;
+    TokenLockSessionKeyValidator tokenLockSessionKeyValidator;
+    TestERC20 erc20;
+    TestUSDC usdc;
+    TestDAI dai;
+    TestUNI uni;
+
+    address alice;
+    uint256 aliceKey;
+    address bob;
+    uint256 bobKey;
+    address solver;
+    uint256 solverKey;
+    address payable beneficiary;
+    address sessionKeyAddr;
+    uint256 sessionKeyPrivate;
+    address sessionKey1Addr;
+    uint256 sessionKey1Private;
+
+    /*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*/
+    /*                   EVENTS                  */
+    /*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*/
+
+    event TLSKV_ModuleInstalled(address wallet);
+    event TLSKV_ModuleUninstalled(address wallet);
+    event TLSKV_SessionKeyEnabled(address sessionKey, address wallet);
+    event TLSKV_SessionKeyDisabled(address sessionKey, address wallet);
+    event TLSKV_SessionKeyPaused(address sessionKey, address wallet);
+    event TLSKV_SessionKeyUnpaused(address sessionKey, address wallet);
+
+    /*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*/
+    /*             HELPER FUNCTIONS              */
+    /*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*/
+
+    function _getPrevValidator(
+        address _validator
+    ) internal view returns (address) {
+        (address[] memory validators, ) = mew.getValidatorPaginated(
+                address(0x1),
+                10
+            );
+        // Presuming that wallet wont have gt 20 different validators installed
+        for (uint256 i = 1; i < 20; i++) {
+            if (validators[i] == _validator) {
+                return validators[i - 1];
+            }
+        }
+    }
+
+    /*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*/
+    /*                    SETUP                  */
+    /*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*/
+
+    function setUp() public override {
+        super.setUp();
+        tokenLockSessionKeyValidator = new TokenLockSessionKeyValidator();
+        erc20 = new TestERC20();
+        usdc = new TestUSDC();
+        dai = new TestDAI();
+        uni = new TestUNI();
+
+        (sessionKeyAddr, sessionKeyPrivate) = makeAddrAndKey("session_key");
+        (sessionKey1Addr, sessionKey1Private) = makeAddrAndKey("session_key_1");
+        (alice, aliceKey) = makeAddrAndKey("alice");
+        (bob, bobKey) = makeAddrAndKey("bob");
+        (solver, solverKey) = makeAddrAndKey("solver");
+        beneficiary = payable(address(makeAddr("beneficiary")));
+        vm.deal(beneficiary, 1 ether);
+    }
+
+    /*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*/
+    /*                    TESTS                  */
+    /*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*§*/
+
+    function test_install_TKSKV_Module() public {
+        mew = setupMEW();
+        vm.startPrank(owner1);
+        // Install another tokenLockSessionKeyValidator module for total of 3
+        Execution[] memory batchCall1 = new Execution[](1);
+        batchCall1[0].target = address(mew);
+        batchCall1[0].value = 0;
+        batchCall1[0].callData = abi.encodeWithSelector(
+            ModularEtherspotWallet.installModule.selector,
+            uint256(1),
+            address(tokenLockSessionKeyValidator),
+            hex""
+        );
+        // Check emitted event
+        vm.expectEmit(false, false, false, true);
+        emit TLSKV_ModuleInstalled(address(mew));
+        defaultExecutor.execBatch(IERC7579Account(mew), batchCall1);
+        assertTrue(mew.isModuleInstalled(1, address(tokenLockSessionKeyValidator), ""));
+    }
+
+    function test_Uninstall_TKSKV_Module() public {
+        mew = setupMEWWithSessionKeys();
+        vm.startPrank(address(mew));
+        // Install another tokenLockSessionKeyValidator module for total of 3
+       
+        Execution[] memory batchCall1 = new Execution[](1);
+        batchCall1[0].target = address(mew);
+        batchCall1[0].value = 0;
+        batchCall1[0].callData = abi.encodeWithSelector(
+            ModularEtherspotWallet.installModule.selector,
+            uint256(1),
+            address(tokenLockSessionKeyValidator),
+            hex""
+        );
+        defaultExecutor.execBatch(IERC7579Account(mew), batchCall1);
+
+        Execution[] memory batchCall0 = new Execution[](1);
+        batchCall0[0].target = address(mew);
+        batchCall0[0].value = 0;
+        batchCall0[0].callData = abi.encodeWithSelector(
+            ModularEtherspotWallet.installModule.selector,
+            uint256(1),
+            address(defaultValidator),
+            hex""
+        );
+        defaultExecutor.execBatch(IERC7579Account(mew), batchCall0);
+
+        // Should be 3 Validator modules installed
+        assertTrue(mew.isModuleInstalled(1, address(ecdsaValidator), ""));
+        assertTrue(mew.isModuleInstalled(1, address(tokenLockSessionKeyValidator), ""));
+        assertTrue(mew.isModuleInstalled(1, address(defaultValidator), ""));
+        
+        address[] memory tokens = new address[](3);
+        tokens[0] = address(usdc);
+        tokens[1] = address(dai);
+        tokens[2] = address(uni);
+
+        uint256[] memory amounts = new uint256[](3);
+        amounts[0] = 100 * 10**6;
+        amounts[1] = 200 * 10**18;
+        amounts[2] = 300 * 10**18;
+
+        uint48 validAfter = uint48(block.timestamp);
+        uint48 validUntil = uint48(block.timestamp + 1 days);
+
+        // Enable session
+        bytes memory sessionData = abi.encodePacked(
+            sessionKeyAddr,
+            solver,
+            IERC20.transfer.selector,
+            validAfter,
+            validUntil,
+            tokens.length,
+            tokens,
+            amounts.length,
+            amounts
+        );
+
+        tokenLockSessionKeyValidator.enableSessionKey(sessionData);
+        assertEq(tokenLockSessionKeyValidator.getAssociatedSessionKeys().length, 1);
+
+        // Get previous tokenLockSessionKeyValidator to pass into uninstall (required for linked list)
+        address prevValidator = _getPrevValidator(address(tokenLockSessionKeyValidator));
+        // Uninstall session key tokenLockSessionKeyValidator
+        Execution[] memory batchCall2 = new Execution[](1);
+        batchCall2[0].target = address(mew);
+        batchCall2[0].value = 0;
+        batchCall2[0].callData = abi.encodeWithSelector(
+            ModularEtherspotWallet.uninstallModule.selector,
+            uint256(1),
+            address(tokenLockSessionKeyValidator),
+            abi.encode(prevValidator, hex"")
+        );
+        // Check emitted event
+        vm.expectEmit(false, false, false, true);
+        emit TLSKV_ModuleUninstalled(address(mew));
+        defaultExecutor.execBatch(IERC7579Account(mew), batchCall2);
+        // Check session key tokenLockSessionKeyValidator is uninstalled
+        assertTrue(mew.isModuleInstalled(1, address(ecdsaValidator), ""));
+        assertFalse(mew.isModuleInstalled(1, address(tokenLockSessionKeyValidator), ""));
+        assertTrue(mew.isModuleInstalled(1, address(defaultValidator), ""));
+        assertFalse(tokenLockSessionKeyValidator.isInitialized(address(mew)));
+        assertEq(tokenLockSessionKeyValidator.getAssociatedSessionKeys().length, 0);
+        vm.stopPrank();
+    }
+
+    function test_pass_TLSKV_enableSessionKey() public {
+        vm.startPrank(alice);
+
+        address[] memory tokens = new address[](3);
+        tokens[0] = address(usdc);
+        tokens[1] = address(dai);
+        tokens[2] = address(uni);
+
+        uint256[] memory amounts = new uint256[](3);
+        amounts[0] = 100 * 10**6;
+        amounts[1] = 200 * 10**18;
+        amounts[2] = 300 * 10**18;
+
+        uint48 validAfter = uint48(block.timestamp);
+        uint48 validUntil = uint48(block.timestamp + 1 days);
+
+        // Enable session
+        bytes memory sessionData = abi.encodePacked(
+            sessionKeyAddr,
+            solver,
+            IERC20.transfer.selector,
+            validAfter,
+            validUntil,
+            tokens.length,
+            tokens,
+            amounts.length,
+            amounts
+        );
+        // Check emitted event
+        vm.expectEmit(false, false, false, true);
+        emit TLSKV_SessionKeyEnabled(sessionKeyAddr, address(alice));
+        tokenLockSessionKeyValidator.enableSessionKey(sessionData);
+        // Session should be enabled
+        assertFalse(
+            tokenLockSessionKeyValidator.getSessionKeyData(sessionKeyAddr).validUntil == 0
+        );
+        vm.stopPrank();
+    }
+
+    function test_pass_TLSKV_validateUserOp() public {
+        mew = setupMEW();
+
+        vm.startPrank(owner1);
+        // Install another tokenLockSessionKeyValidator module for total of 3
+        Execution[] memory batchCall1 = new Execution[](1);
+        batchCall1[0].target = address(mew);
+        batchCall1[0].value = 0;
+        batchCall1[0].callData = abi.encodeWithSelector(
+            ModularEtherspotWallet.installModule.selector,
+            uint256(1),
+            address(tokenLockSessionKeyValidator),
+            hex""
+        );
+        // Check emitted event
+        vm.expectEmit(false, false, false, true);
+        emit TLSKV_ModuleInstalled(address(mew));
+        defaultExecutor.execBatch(IERC7579Account(mew), batchCall1);
+        vm.stopPrank();
+
+        // Enable valid session
+        
+        address[] memory tokens = new address[](3);
+        tokens[0] = address(usdc);
+        tokens[1] = address(dai);
+        tokens[2] = address(uni);
+
+        uint256[] memory amounts = new uint256[](3);
+        amounts[0] = 100 * 10**6;
+        amounts[1] = 200 * 10**18;
+        amounts[2] = 300 * 10**18;
+
+        vm.deal(address(mew), 1 ether);
+        vm.startPrank(address(mew));
+        
+        usdc.mint(address(mew), amounts[0]);
+        assertEq(usdc.balanceOf(address(mew)), amounts[0]);
+        usdc.approve(address(bob), amounts[0]);
+        usdc.approve(address(mew), amounts[0]);
+
+        dai.mint(address(mew), amounts[1]);
+        assertEq(dai.balanceOf(address(mew)), amounts[1]);
+        dai.approve(address(bob), amounts[1]);
+
+        uni.mint(address(mew), amounts[2]);
+        assertEq(uni.balanceOf(address(mew)), amounts[2]);
+        uni.approve(address(bob), amounts[2]);
+
+        uint48 validAfter = uint48(block.timestamp);
+        uint48 validUntil = uint48(block.timestamp + 1 days);
+
+        // Enable session
+        bytes memory sessionData = abi.encodePacked(
+            sessionKeyAddr,
+            solver,
+            IERC20.transferFrom.selector,
+            validAfter,
+            validUntil,
+            tokens.length,
+            tokens,
+            amounts.length,
+            amounts
+        );
+
+        tokenLockSessionKeyValidator.enableSessionKey(sessionData);
+        assertEq(tokenLockSessionKeyValidator.getAssociatedSessionKeys().length, 1);
+
+        // Construct user op data
+        bytes memory data = abi.encodeWithSelector(
+            IERC20.transferFrom.selector,
+            address(mew),
+            address(bob),
+            amounts[0]
+        );
+        bytes memory userOpCalldata = abi.encodeCall(
+            IERC7579Account.execute,
+            (
+                ModeLib.encodeSimpleSingle(),
+                ExecutionLib.encodeSingle(address(usdc), uint256(0), data)
+            )
+        );
+        PackedUserOperation memory userOp = entrypoint.fillUserOp(
+            address(mew),
+            userOpCalldata
+        );
+
+        userOp.nonce = getNonce(address(mew), address(tokenLockSessionKeyValidator));
+        bytes32 hash = entrypoint.getUserOpHash(userOp);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(
+            sessionKeyPrivate,
+            ECDSA.toEthSignedMessageHash(hash)
+        );
+        bytes memory signature = abi.encodePacked(r, s, v);
+        userOp.signature = signature;
+        // Validation should succeed
+        PackedUserOperation[] memory userOps = new PackedUserOperation[](1);
+        userOps[0] = userOp;
+        entrypoint.handleOps(userOps, beneficiary);
+        assertEq(usdc.balanceOf(address(bob)), amounts[0]);
+    }
+}


### PR DESCRIPTION
# TokenLockSessionKeyValidator enhanced to support multiple tokens and their addresses

## Description

- multiple tokens can be associated with a Sessionkey in TokenLockSessionKeyValidator
- SessionKey is created/enabled on TokenLockSessionKeyValidator exclusively to support solver funding activity on target chain

## Types of changes
- [X] New feature (non-breaking change which adds functionality)
