### PR TITLE
credible account disable sessionkey & Uninstall enhancements

### DIFF
--- a/src/modular-etherspot-wallet/modules/validators/CredibleAccountValidator.sol
+++ b/src/modular-etherspot-wallet/modules/validators/CredibleAccountValidator.sol
@@ -12,7 +12,7 @@ import "../../erc7579-ref-impl/libs/ExecutionLib.sol";
 import {ICredibleAccountValidator} from "../../interfaces/ICredibleAccountValidator.sol";
 import {ArrayLib} from "../../libraries/ArrayLib.sol";
 
-import "forge-std/console2.sol";
+import "forge-std/console.sol";
 
 contract CredibleAccountValidator is ICredibleAccountValidator {
     using ModeLib for ModeCode;
@@ -120,16 +120,13 @@ contract CredibleAccountValidator is ICredibleAccountValidator {
         }
 
         if(sessionData[_session][msg.sender].validUntil > block.timestamp) {
-            revert CredibleAccountValidator_SessionKeyActive(_session);
-        }
-
-        uint256 tokenCount = sessionData[_session][msg.sender].lockedTokens.length;
-        for (uint256 i; i < tokenCount; ++i) {
-            address tokenAddress = sessionData[_session][msg.sender].lockedTokens[i].token;
-            (uint256 lockedAmount, uint256 claimedAmount) = 
-            getTokenAmounts(_session, tokenAddress);
-            if (lockedAmount != claimedAmount) {
-                revert CredibleAccountValidator_LockedTokensNotClaimed(_session);
+            uint256 tokenCount = sessionData[_session][msg.sender].lockedTokens.length;
+            for (uint256 i; i < tokenCount; ++i) {
+                (uint256 lockedAmount, uint256 claimedAmount) = 
+                getTokenAmounts(_session, sessionData[_session][msg.sender].lockedTokens[i].token);
+                if (lockedAmount != claimedAmount) {
+                    revert CredibleAccountValidator_LockedTokensNotClaimed(_session);
+                }
             }
         }
 
@@ -226,8 +223,7 @@ contract CredibleAccountValidator is ICredibleAccountValidator {
      *      - 32 bytes for `r`
      *      - 32 bytes for `s`
      *      - 1 byte for `v`
-     *      - 32 bytes for `merkleRoot`
-     *      - 32 bytes for at least one entry in the `merkleProof`
+     *      - 32 bytes for at least one entry in the `proof`
      * @param userOp The packed user operation containing the signature and other data.
      * @param userOpHash The hash of the user operation.
      * @return A status code indicating the result of the validation.
@@ -236,13 +232,12 @@ contract CredibleAccountValidator is ICredibleAccountValidator {
         PackedUserOperation calldata userOp,
         bytes32 userOpHash
     ) external override returns (uint256) {
-        if (userOp.signature.length < 129) {
+        if (userOp.signature.length < 65) {
             return VALIDATION_FAILED;
         }
         (
             bytes memory signature,
-            bytes32 merkleRoot,
-            bytes32[] memory merkleProof
+            bytes memory proof
         ) = _digestSignature(userOp.signature);
         address sessionKeySigner = ECDSA.recover(
             ECDSA.toEthSignedMessageHash(userOpHash),
@@ -251,9 +246,9 @@ contract CredibleAccountValidator is ICredibleAccountValidator {
         if (!validateSessionKeyParams(sessionKeySigner, userOp)) {
             return VALIDATION_FAILED;
         }
-        // Validate the Merkle proof (userOpHash is considered the leaf)
-        // this is only stub method and to be replaced with actual Merkle proof validation logic
-        if (!validateProof(merkleProof, merkleRoot, userOpHash)) {
+        // Validate the proof
+        // this is only stub method and to be replaced with actual proof validation logic
+        if (!validateProof(proof)) {
             return VALIDATION_FAILED;
         }
         SessionData storage sd = sessionData[sessionKeySigner][msg.sender];
@@ -263,11 +258,9 @@ contract CredibleAccountValidator is ICredibleAccountValidator {
 
     // Stub method to validate Merkle proof
     function validateProof(
-        bytes32[] memory _proof,
-        bytes32 _root,
-        bytes32 _leaf
+        bytes memory proof
     ) public pure returns (bool) {
-        if (_proof.length == 0 || _root == bytes32(0)) {
+        if (proof.length == 0) {
             return false;
         }
         // Placeholder for actual Merkle proof validation logic
@@ -424,6 +417,10 @@ contract CredibleAccountValidator is ICredibleAccountValidator {
         } else if (_selector == IERC20.transferFrom.selector) {
             if (IERC20(_token).balanceOf(_userOpSender) < _amount) return false;
         }
+
+        if((_amount > _lockedTokens[idx].lockedAmount) || 
+        (_amount + _lockedTokens[idx].claimedAmount > _lockedTokens[idx].lockedAmount)) return false;
+
         SessionData storage sd = sessionData[_sessionKey][_userOpSender];
         // incrementing the claimed amount for the token
         sd.lockedTokens[idx].claimedAmount += _amount;
@@ -462,12 +459,11 @@ contract CredibleAccountValidator is ICredibleAccountValidator {
         }
     }
 
-    /// @notice Extracts signature components, merkle root, and merkle proof from the provided data
-    /// @dev Decodes the signature, merkle root, and merkle proof from a single bytes array
-    /// @param _signature The combined signature, merkle root, and merkle proof data
+    /// @notice Extracts signature components and proof from the provided data
+    /// @dev Decodes the signature, and proof from a single bytes array
+    /// @param _signature The combined signature, proof data
     /// @return signature The extracted signature (r, s, v)
-    /// @return merkleRoot The extracted merkle root
-    /// @return merkleProof The extracted merkle proof as an array of bytes32
+    /// @return proof The proof
     function _digestSignature(
         bytes calldata _signature
     )
@@ -475,32 +471,31 @@ contract CredibleAccountValidator is ICredibleAccountValidator {
         view
         returns (
             bytes memory signature,
-            bytes32 merkleRoot,
-            bytes32[] memory merkleProof
+            bytes memory proof
         )
     {
         bytes32 r = bytes32(_signature[0:32]);
         bytes32 s = bytes32(_signature[32:64]);
         uint8 v = uint8(_signature[64]);
-        merkleRoot = bytes32(_signature[65:97]);
+
+        bytes memory proof = bytes(_signature[65:]);
 
         signature = abi.encodePacked(r, s, v);
 
-        // r (32 bytes) + s (32 bytes) + v (1 byte) + merkleRoot (32 bytes) = 97 bytes.
-        uint256 proofLength = (_signature.length - 97) / 32;
+        // r (32 bytes) + s (32 bytes) + v (1 byte) = 65 bytes.
+       // uint256 proofLength = _signature.length - 65;
+        
+        // proof = new bytes(proofLength);
 
-        merkleProof = new bytes32[](proofLength);
+        // if (proofLength > 0) {
+        //     uint256 proofStart = 65; // 32 byte r + 32 byte s + 1 byte v
+        //     for (uint256 i; i < proofLength; ++i) {
+        //         proof[i] = _signature[proofStart + i];
+        //     }
+        // }
 
-        if (proofLength > 0) {
-            uint256 proofStart = 97; // 32 byte r + 32 byte s + 1 byte v + 32 byte merkleRoot
-            for (uint256 i; i < proofLength; ++i) {
-                merkleProof[i] = bytes32(
-                    _signature[proofStart + (i * 32):proofStart +
-                        ((i + 1) * 32)]
-                );
-            }
-        }
 
-        return (signature, merkleRoot, merkleProof);
+
+        return (signature, proof);
     }
 }

--- a/test/foundry/TestAdvancedUtils.t.sol
+++ b/test/foundry/TestAdvancedUtils.t.sol
@@ -25,6 +25,7 @@ contract TestAdvancedUtils is BootstrapUtil, Test {
     ModularEtherspotWallet implementation;
     ModularEtherspotWalletFactory factory;
     IEntryPoint entrypoint = IEntryPoint(ENTRYPOINT_ADDR);
+    bytes public constant DUMMY_PROOF = hex"1234567890abcdef";
 
     MockValidator defaultValidator;
     MockExecutor defaultExecutor;
@@ -370,38 +371,5 @@ contract TestAdvancedUtils is BootstrapUtil, Test {
         vm.deal(address(mewAccount), 100 ether);
         vm.stopPrank();
         return mewAccount;
-    }
-
-    function getDummyMerkleRootAndProof() public pure returns (bytes32, bytes32[] memory) {
-        // Generate a dummy Merkle root of type bytes32
-        bytes32 merkleRoot = bytes32("0x1234567890abcdef");
-
-        // Generate a dummy Merkle proof of type bytes32[] with length 1
-        bytes32[] memory merkleProof = new bytes32[](1);
-        merkleProof[0] = bytes32("0x1234567890abcdef");
-
-        return (merkleRoot, merkleProof);
-    }
-
-    function getDummyMerkleRootAndInvalidProof() public pure returns (bytes32, bytes32[] memory) {
-        // Generate a dummy Merkle root of type bytes32
-        bytes32 merkleRoot = bytes32("0x1234567890abcdef");
-
-        // Generate a dummy Merkle proof of type bytes32[] with length 1
-        bytes32[] memory merkleProof = new bytes32[](0);
-
-        return (merkleRoot, merkleProof);
-    }
-
-    function getDummyInvalidMerkleRootAndProof() public pure returns (bytes32, bytes32[] memory) {
-        // Generate a dummy Merkle root of type bytes32
-        bytes32 merkleRoot = bytes32(0);
-
-        // Generate a dummy Merkle proof of type bytes32[] with length 1
-        bytes32[] memory merkleProof = new bytes32[](1);
-        merkleProof[0] = bytes32("0x1234567890abcdef");
-
-        return (merkleRoot, merkleProof);
-
     }
 }

--- a/test/foundry/harnesses/CredibleAccountValidatorHarness.sol
+++ b/test/foundry/harnesses/CredibleAccountValidatorHarness.sol
@@ -55,16 +55,15 @@ contract CredibleAccountValidatorHarness is CredibleAccountValidator {
     }
 
     function exposed_digestSignature(
-        bytes calldata _signatureWithMerkleProof
+        bytes calldata _signatureWithProof
     )
         external
         view
         returns (
             bytes memory signature,
-            bytes32 merkleRoot,
-            bytes32[] memory merkleProof
+            bytes memory proof
         )
     {
-        return _digestSignature(_signatureWithMerkleProof);
+        return _digestSignature(_signatureWithProof);
     }
 }

--- a/test/foundry/modules/CredibleAccountHook/concrete/CredibleAccountHook.t.sol
+++ b/test/foundry/modules/CredibleAccountHook/concrete/CredibleAccountHook.t.sol
@@ -10,6 +10,7 @@ import "../../../../../src/modular-etherspot-wallet/erc7579-ref-impl/libs/ModeLi
 import "../../../../../src/modular-etherspot-wallet/erc7579-ref-impl/libs/ExecutionLib.sol";
 import "../../../TestAdvancedUtils.t.sol";
 import "../../../../../src/modular-etherspot-wallet/utils/ERC4337Utils.sol";
+import "forge-std/console.sol";
 
 using ERC4337Utils for IEntryPoint;
 

--- a/test/foundry/modules/CredibleAccountHook/utils/CredibleAccountHookTestUtils.sol
+++ b/test/foundry/modules/CredibleAccountHook/utils/CredibleAccountHookTestUtils.sol
@@ -221,9 +221,8 @@ contract CredibleAccountHookTestUtils is TestAdvancedUtils {
         );
 
         if(_validator == address(caValidator)) {
-            (bytes32 merkleRoot, bytes32[] memory merkleProof) = getDummyMerkleRootAndProof();
-            // append r, s, v of signature followed by merkleRoot and merkleProof to the signature
-            userOp.signature = abi.encodePacked(r, s, v, merkleRoot, merkleProof);
+            // append r, s, v of signature followed by Proof to the signature
+            userOp.signature = abi.encodePacked(r, s, v, DUMMY_PROOF);
         } else {
             userOp.signature = abi.encodePacked(r, s, v);
         }
@@ -238,10 +237,8 @@ contract CredibleAccountHookTestUtils is TestAdvancedUtils {
             ECDSA.toEthSignedMessageHash(hash)
         );
         
-        (bytes32 merkleRoot, bytes32[] memory merkleProof) = getDummyMerkleRootAndProof();
-
-        // append r, s, v of signature followed by merkleRoot and merkleProof to the signature
-        return abi.encodePacked(r, s, v, merkleRoot, merkleProof);
+        // append r, s, v of signature followed by dummy-proof to the signature
+        return abi.encodePacked(r, s, v, DUMMY_PROOF);
     }
 
     function _executeUserOperation(

--- a/test/foundry/modules/CredibleAccountValidator/utils/CredibleAccountValidatorTestUtils.sol
+++ b/test/foundry/modules/CredibleAccountValidator/utils/CredibleAccountValidatorTestUtils.sol
@@ -40,6 +40,7 @@ contract CredibleAccountValidatorTestUtils is TestAdvancedUtils {
     address internal invalidSessionKey;
     address payable internal immutable beneficiary;
     address payable internal immutable receiver;
+    address payable internal immutable dummySessionKey;
 
     // Test variables
     address internal immutable solver = address(0xdeadbeef);
@@ -62,6 +63,12 @@ contract CredibleAccountValidatorTestUtils is TestAdvancedUtils {
         );
         receiver = payable(
             address(uint160(uint256(keccak256(abi.encodePacked("receiver")))))
+        );
+
+        dummySessionKey = payable(
+            address(
+                uint160(uint256(keccak256(abi.encodePacked("dummySessionKey"))))
+            )
         );
     }
 
@@ -158,24 +165,6 @@ contract CredibleAccountValidatorTestUtils is TestAdvancedUtils {
         assertEq(sessionDataQueried.lockedTokens.length, amounts.length);
         assertEq(sessionDataQueried.solver, solver);
         return (sessionKey, sessionDataQueried);
-    }
-
-    function _disableSessionKeyAndValidate(
-        ModularEtherspotWallet _modularWallet,
-        address _sessionKey
-    ) public {
-        vm.expectEmit(true, true, true, true);
-        emit ICAV.CredibleAccountValidator_SessionKeyDisabled(
-            _sessionKey,
-            address(_modularWallet)
-        );
-        credibleAccountValidator.disableSessionKey(_sessionKey);
-        ICAV.SessionData memory sessionData = credibleAccountValidator
-            .getSessionKeyData(_sessionKey);
-        assertEq(sessionData.validUntil, 0);
-        assertEq(sessionData.validAfter, 0);
-        assertEq(sessionData.selector, bytes4(0));
-        assertEq(sessionData.lockedTokens.length, 0);
     }
 
     function _createUserOpWithSignature(

--- a/test/foundry/modules/CredibleAccountValidator/utils/CredibleAccountValidatorTestUtils.sol
+++ b/test/foundry/modules/CredibleAccountValidator/utils/CredibleAccountValidatorTestUtils.sol
@@ -203,13 +203,8 @@ contract CredibleAccountValidatorTestUtils is TestAdvancedUtils {
             bytes32 s
         ) = _createUserOpWithSignature(_account, _callData, _signerKey);
 
-        (
-            bytes32 merkleRoot,
-            bytes32[] memory merkleProof
-        ) = getDummyMerkleRootAndProof();
-
         // append r, s, v of signature followed by merkleRoot and merkleProof to the signature
-        userOp.signature = abi.encodePacked(r, s, v, merkleRoot, merkleProof);
+        userOp.signature = abi.encodePacked(r, s, v, DUMMY_PROOF);
 
         return (hash, userOp);
     }
@@ -227,13 +222,8 @@ contract CredibleAccountValidatorTestUtils is TestAdvancedUtils {
             bytes32 s
         ) = _createUserOpWithSignature(_account, _callData, _signerKey);
 
-        (
-            bytes32 merkleRoot,
-            bytes32[] memory merkleProof
-        ) = getDummyMerkleRootAndProof();
-
         // append r, s, v of signature followed by merkleRoot and merkleProof to the signature
-        userOp.signature = abi.encodePacked(r, s, v, merkleRoot, merkleProof);
+        userOp.signature = abi.encodePacked(r, s, v, DUMMY_PROOF);
 
         return (hash, userOp);
     }


### PR DESCRIPTION
## Description
credible account disable sessionKey & Uninstall enhancements

## Changes

1. Checks for sessionKey during `disableSessionKey` execution
    - If SessionKey is Active and All Tokens are Not Claimed -> then revert the execution
    - If SessionKey is Expired and Tokens are Partially Claimed -> Allow Disable SessionKey
    - If SessionKey is Expired and Tokens are not Claimed -> Allow Disable SessionKey


2. Checks for Uninstall CredibleAccountModule execution
    - If any SessionKey is Active & UnClaimed -> then revert the execution
    - If all SessionKeys are Expired -> Uninstall is Allowed
    - If all SessionKeys are expired and even when any of them are unclaimed or partiallyClaimed. -> Uninstall is allowed

## How Has This Been Tested?
- Foundry Tests coverage for `disableSessionKey` and `UninstallModule` enhancements and fixes

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)

@lbw33 @ch4r10t33r 
